### PR TITLE
a typo in leaderboard link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [DeepTraffic](https://selfdrivingcars.mit.edu/deeptraffic) - [Visualization](https://selfdrivingcars.mit.edu/deeptraffic-visualization) - [Leaderboard](https://selfdrivingcars.mit.edu/deeptraffic-leaderboard) - [Documentation](https://selfdrivingcars.mit.edu/deeptraffic-documentation) - [Paper](https://arxiv.org/abs/1801.02805) - [MIT Deep Learning](https://deeplearning.mit.edu/)
 
-DeepTraffic is a deep reinforcement learning competition hosted as part of the [MIT Deep Learning](https://deeplearning.mit.edu) courses. The goal is to create a neural network that drives a vehicle (or multiple vehicles) as fast as possible through dense highway traffic. Top 10 submissions are listed on the  [leaderboard](https://selfdrivingcars.mit.edu/deeptraffic-leaderboard/}) and you'll be able to [visualize](https://selfdrivingcars.mit.edu/deeptraffic-visualization/) your submission in the following way:
+DeepTraffic is a deep reinforcement learning competition hosted as part of the [MIT Deep Learning](https://deeplearning.mit.edu) courses. The goal is to create a neural network that drives a vehicle (or multiple vehicles) as fast as possible through dense highway traffic. Top 10 submissions are listed on the  [leaderboard](https://selfdrivingcars.mit.edu/deeptraffic-leaderboard/) and you'll be able to [visualize](https://selfdrivingcars.mit.edu/deeptraffic-visualization/) your submission in the following way:
 
 ![DeepTraffic visualization](images/deeptraffic-visualization-example.gif)
 


### PR DESCRIPTION
The extra curly brace results in "%7D" appended to the link. https://selfdrivingcars.mit.edu/deeptraffic-leaderboard/%7D

`...deeptraffic-leaderboard/}`
↓↓
`...deeptraffic-leaderboard/`

